### PR TITLE
Change LIBS to LDLIBS

### DIFF
--- a/ex28/c-skeleton/Makefile
+++ b/ex28/c-skeleton/Makefile
@@ -1,5 +1,5 @@
 CFLAGS=-g -O2 -Wall -Wextra -Isrc -rdynamic -DNDEBUG $(OPTFLAGS)
-LIBS=-ldl $(OPTLIBS)
+LDLIBS=-ldl $(OPTLIBS)
 PREFIX?=/usr/local
 
 SOURCES=$(wildcard src/**/*.c src/*.c)


### PR DESCRIPTION
The variable to set to invoke the linker is LDLIBS. The existing makefile will not work as described in the text without this. I noticed code like ex29.c will compile without the -ldl flag set when I compiled with clang on OSX.
